### PR TITLE
Settings and labels

### DIFF
--- a/identifytool.py
+++ b/identifytool.py
@@ -63,6 +63,17 @@ class FeatureDock(QDockWidget):
 
         self.main_layout.addLayout(coord_layout)
 
+        # Label und Darstellung
+        label_layout = QHBoxLayout()
+        self.label_textfield_label = QLabel("Label:")
+        label_layout.addWidget(self.label_textfield_label)
+        self.label_textfield = QLineEdit()
+        label_layout.addWidget(self.label_textfield)
+        self.cb_enable_label = QCheckBox("Label auf Karte zeigen")
+        label_layout.addWidget(self.cb_enable_label)
+        self.main_layout.addLayout(label_layout)
+
+
         # Größen-SpinBox und Schieberegler
         size_layout = QHBoxLayout()
         self.size_label = QLabel("Größe:")
@@ -114,27 +125,6 @@ class FeatureDock(QDockWidget):
         rotation_layout.addWidget(self.rotation_value_label)
 
         self.main_layout.addLayout(rotation_layout)
-
-        # Label-Sektion (vorerst ausgeblendet, Code bleibt für später erhalten)
-        label_layout = QVBoxLayout()
-        self.label_text_label = QLabel("Label:")
-        label_layout.addWidget(self.label_text_label)
-
-        self.label_input = QLineEdit()
-        self.label_input.setPlaceholderText("Label-Text eingeben...")
-        self.label_input.setStyleSheet("QLineEdit { padding: 4px; border: 1px solid #ccc; border-radius: 3px; }")
-        label_layout.addWidget(self.label_input)
-
-        self.main_layout.addLayout(label_layout)
-
-        # Label-Anzeige-Checkbox (vorerst ausgeblendet, Code bleibt für später erhalten)
-        self.show_label_checkbox = QCheckBox("Label anzeigen")
-        self.main_layout.addWidget(self.show_label_checkbox)
-
-        # Label-Funktion vorerst ausblenden
-        self.label_text_label.hide()
-        self.label_input.hide()
-        self.show_label_checkbox.hide()
 
         # Weißer Hintergrund-Checkbox
         self.white_background_checkbox = QCheckBox("Weißer Hintergrund")
@@ -191,9 +181,9 @@ class FeatureDock(QDockWidget):
         self.rotation_label.hide()
         self.rotation_slider.hide()
         self.rotation_value_label.hide()
-        self.label_text_label.hide()
-        self.label_input.hide()
-        self.show_label_checkbox.hide()
+        self.label_textfield_label.hide()
+        self.label_textfield.hide()
+        self.cb_enable_label.hide()
         self.white_background_checkbox.hide()
         self.btn_delete.hide()
 
@@ -372,9 +362,9 @@ class FeatureDock(QDockWidget):
         self.rotation_slider.show()
         self.rotation_value_label.show()
         # Label-Funktion vorerst ausgeblendet (Code bleibt für später erhalten)
-        # self.label_text_label.show()
-        # self.label_input.show()
-        # self.show_label_checkbox.show()
+        self.label_textfield_label.show()
+        self.label_textfield.show()
+        self.cb_enable_label.show()
         self.white_background_checkbox.show()
         self.btn_delete.show()
 
@@ -397,8 +387,8 @@ class FeatureDock(QDockWidget):
         except:
             label_text = ""
             show_label = False
-        self.label_input.setText(label_text)
-        self.show_label_checkbox.setChecked(show_label)
+        self.label_textfield.setText(label_text)
+        self.cb_enable_label.setChecked(show_label)
 
         # Weißer Hintergrund-Wert setzen
         try:
@@ -429,11 +419,11 @@ class FeatureDock(QDockWidget):
         self.scale_checkbox.stateChanged.disconnect() if self.scale_checkbox.receivers(
             self.scale_checkbox.stateChanged
         ) > 0 else None
-        self.label_input.textChanged.disconnect() if self.label_input.receivers(
-            self.label_input.textChanged
+        self.label_textfield.textChanged.disconnect() if self.label_textfield.receivers(
+            self.label_textfield.textChanged
         ) > 0 else None
-        self.show_label_checkbox.stateChanged.disconnect() if self.show_label_checkbox.receivers(
-            self.show_label_checkbox.stateChanged
+        self.cb_enable_label.stateChanged.disconnect() if self.cb_enable_label.receivers(
+            self.cb_enable_label.stateChanged
         ) > 0 else None
         self.white_background_checkbox.stateChanged.disconnect() if self.white_background_checkbox.receivers(
             self.white_background_checkbox.stateChanged
@@ -450,8 +440,8 @@ class FeatureDock(QDockWidget):
         self.size_spinbox.valueChanged.connect(self.on_size_change)
         self.size_slider.valueChanged.connect(self.on_size_change)
         self.scale_checkbox.stateChanged.connect(self.on_scale_toggle)
-        self.label_input.textChanged.connect(self.on_label_changed)
-        self.show_label_checkbox.stateChanged.connect(self.on_show_label_toggle)
+        self.label_textfield.textChanged.connect(self.on_label_changed)
+        self.cb_enable_label.stateChanged.connect(self.on_show_label_toggle)
         self.white_background_checkbox.stateChanged.connect(self.on_white_background_toggle)
         self.rotation_slider.valueChanged.connect(self.on_rotation_change)
         self.rotation_slider.sliderReleased.connect(self.on_rotation_slider_released)

--- a/thwtoolboxplugin.py
+++ b/thwtoolboxplugin.py
@@ -1699,7 +1699,7 @@ class THWToolboxPlugin:
         button_box.rejected.connect(dialog.reject)
 
         result = dialog.exec_()
-        if result is not QDialog.Rejected:
+        if result == QDialog.Accepted:
             self.settings.new_icon_scaling_with_map = cb_scale.isChecked()
             self.settings.new_icon_fixed_size = cb_fixed_size.isChecked()
             self.settings.new_icon_size = spin_icon_size.value()

--- a/thwtoolboxplugin.py
+++ b/thwtoolboxplugin.py
@@ -7,8 +7,11 @@ from PyQt5.QtGui import QColor, QDrag, QIcon, QPixmap
 from PyQt5.QtWidgets import (
     QAction,
     QCheckBox,
+    QComboBox,
     QDialog,
+    QDialogButtonBox,
     QDockWidget,
+    QFormLayout,
     QHBoxLayout,
     QInputDialog,
     QLabel,
@@ -17,6 +20,7 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QPushButton,
     QSlider,
+    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
@@ -305,6 +309,13 @@ class MoveTool(QgsMapTool):
 
 
 class THWToolboxPlugin:
+
+    # Default values for settings
+    SCALING_ICON_WITH_MAP_DEFAULT = False
+    ICON_FIXED_SIZE_DEFAULT = False
+    DEFAULT_ICON_SIZE_DEFAULT = 50
+    DEFAULT_LABEL_CRS_DEFAULT = "MGRS"
+
     def __init__(self, iface):
         self.iface = iface
         self.canvas = iface.mapCanvas()
@@ -316,6 +327,13 @@ class THWToolboxPlugin:
         self.move_tool = None
         self.action = None
         self.dock = None
+
+        self.settings = {
+            "scaling_icon_with_map": self.SCALING_ICON_WITH_MAP_DEFAULT,
+            "icon_fixed_size": self.ICON_FIXED_SIZE_DEFAULT,
+            "default_icon_size": self.DEFAULT_ICON_SIZE_DEFAULT,
+            "default_label_crs": self.DEFAULT_LABEL_CRS_DEFAULT,
+        }
 
     def _check_map_available(self):
         """Prüft, ob eine Karte vorhanden ist (CRS gesetzt und Layer im Projekt)."""
@@ -453,6 +471,9 @@ class THWToolboxPlugin:
             self.move_tool = MoveTool(self.canvas, self)
         self.canvas.setMapTool(self.move_tool)
 
+        # Load the configuration settings
+        self._load_settings()
+
         # Plugin-Symbol als aktiv markieren
         if self.action:
             self.action.setChecked(True)
@@ -568,7 +589,7 @@ class THWToolboxPlugin:
             return
         self.dock = QDockWidget("Taktische Zeichen", self.iface.mainWindow())
         self.dock.setAllowedAreas(Qt.RightDockWidgetArea)
-        self.svg_dock_widget = SvgDock(self.plugin_dir, self._on_svg_drag_start)
+        self.svg_dock_widget = SvgDock(self.plugin_dir, self._on_svg_drag_start, self._open_config_dialog)
         self.dock.setWidget(self.svg_dock_widget)
         self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dock)
 
@@ -1110,6 +1131,9 @@ class THWToolboxPlugin:
             print("DEBUG: Kein Projektpfad verfügbar")
             return
 
+        # Save the settings
+        self._save_settings()
+
         # Aktuelle Datei-Pfad ermitteln
         current_source = self.layer.source().split("|")[0]
         print(f"DEBUG: Aktuelle Layer-Datei: {current_source}")
@@ -1445,29 +1469,32 @@ class THWToolboxPlugin:
         else:
             relative_path = svg_path
 
-        # Intelligente Größenberechnung basierend auf dem aktuellen Zoom-Faktor
-        map_units_per_pixel = self.canvas.mapUnitsPerPixel()
-        # Berechne eine geeignete Größe basierend auf dem Zoom-Faktor
-        # Bei kleineren map_units_per_pixel (starker Zoom) = größere Symbole
-        # Bei größeren map_units_per_pixel (schwacher Zoom) = kleinere Symbole
-        base_size = 30.0  # Basis-Größe
-        zoom_factor = 1.0 / max(map_units_per_pixel, 0.001)  # Vermeide Division durch Null
-        adaptive_size = base_size * zoom_factor
+        if self.settings.get("icon_fixed_size", self.ICON_FIXED_SIZE_DEFAULT):
+            icon_size = self.settings.get("default_icon_size", self.DEFAULT_ICON_SIZE_DEFAULT)
+        else:
+            # Intelligente Größenberechnung basierend auf dem aktuellen Zoom-Faktor
+            map_units_per_pixel = self.canvas.mapUnitsPerPixel()
+            # Berechne eine geeignete Größe basierend auf dem Zoom-Faktor
+            # Bei kleineren map_units_per_pixel (starker Zoom) = größere Symbole
+            # Bei größeren map_units_per_pixel (schwacher Zoom) = kleinere Symbole
+            base_size = 30.0  # Basis-Größe
+            zoom_factor = 1.0 / max(map_units_per_pixel, 0.001)  # Vermeide Division durch Null
+            icon_size = base_size * zoom_factor
 
-        # Prüfe, ob bereits Symbole vorhanden sind und verwende mindestens die Größe des kleinsten Symbols
-        if self.layer.featureCount() > 0:
-            min_existing_size = float("inf")
-            for feature in self.layer.getFeatures():
-                feature_size = feature.attribute("size")
-                if feature_size and feature_size > 0:
-                    min_existing_size = min(min_existing_size, feature_size)
+            # Prüfe, ob bereits Symbole vorhanden sind und verwende mindestens die Größe des kleinsten Symbols
+            if self.layer.featureCount() > 0:
+                min_existing_size = float("inf")
+                for feature in self.layer.getFeatures():
+                    feature_size = feature.attribute("size")
+                    if feature_size and feature_size > 0:
+                        min_existing_size = min(min_existing_size, feature_size)
 
-            # Wenn ein kleinstes Symbol gefunden wurde, verwende mindestens dessen Größe
-            if min_existing_size != float("inf"):
-                adaptive_size = max(adaptive_size, min_existing_size)
+                # Wenn ein kleinstes Symbol gefunden wurde, verwende mindestens dessen Größe
+                if min_existing_size != float("inf"):
+                    icon_size = max(icon_size, min_existing_size)
 
-        # Begrenze die Größe auf einen vernünftigen Bereich
-        adaptive_size = max(10.0, min(500.0, adaptive_size))
+            # Begrenze die Größe auf einen vernünftigen Bereich
+            icon_size = max(10.0, min(500.0, icon_size))
         # Standard-Label aus SVG-Namen erstellen
         svg_name = os.path.basename(svg_path)
         # Entferne .svg Endung und ersetze Unterstriche durch Leerzeichen
@@ -1479,8 +1506,8 @@ class THWToolboxPlugin:
         f.setAttribute("name", os.path.basename(svg_path))
         f.setAttribute("svg_path", relative_path)  # Relativer Pfad
         f.setAttribute("svg_content", svg_content)  # SVG-Inhalt speichern
-        f.setAttribute("size", adaptive_size)  # Adaptive Größe basierend auf Zoom-Faktor
-        f.setAttribute("scale_with_map", False)  # Standardmäßig nicht mit Karte skalieren
+        f.setAttribute("size", icon_size)  # Adaptive Größe basierend auf Zoom-Faktor
+        f.setAttribute("scale_with_map", self.settings.get("scaling_icon_with_map", self.SCALING_ICON_WITH_MAP_DEFAULT))  # Standardmäßig nicht mit Karte skalieren
         f.setAttribute("unique_id", str(uuid.uuid4()))  # Eindeutige ID generieren
         f.setAttribute("label", default_label)  # Standard-Label aus SVG-Namen
         f.setAttribute("show_label", False)  # Label standardmäßig nicht anzeigen
@@ -1661,6 +1688,87 @@ class THWToolboxPlugin:
 
         # Layer-Referenzen in anderen Klassen aktualisieren
         self._update_tool_references()
+
+    def _load_settings(self):
+        proj = QgsProject.instance()
+
+        scaling_icon_with_map_loaded, scaling_icon_with_map_ok = proj.readBoolEntry("taktischezeichen", "scaling_icon_with_map", self.SCALING_ICON_WITH_MAP_DEFAULT)
+        icon_fixed_size_loaded, icon_fixed_size_ok = proj.readBoolEntry("taktischezeichen", "icon_fixed_size", self.ICON_FIXED_SIZE_DEFAULT)
+        default_icon_size_loaded, default_icon_size_ok = proj.readNumEntry("taktischezeichen", "default_icon_size", self.DEFAULT_ICON_SIZE_DEFAULT)
+        default_label_crs_loaded, default_label_crs_ok = proj.readEntry("taktischezeichen", "default_label_crs", self.DEFAULT_LABEL_CRS_DEFAULT)
+
+        print(f"DEBUG: Tried to load settings with result {scaling_icon_with_map_ok} and return {scaling_icon_with_map_loaded}")
+        self.settings["scaling_icon_with_map"] = scaling_icon_with_map_loaded if scaling_icon_with_map_ok else self.SCALING_ICON_WITH_MAP_DEFAULT
+        self.settings["icon_fixed_size"] = icon_fixed_size_loaded if icon_fixed_size_ok else self.ICON_FIXED_SIZE_DEFAULT
+        self.settings["default_icon_size"] = default_icon_size_loaded if default_icon_size_ok else self.DEFAULT_ICON_SIZE_DEFAULT
+        self.settings["default_label_crs"] = default_label_crs_loaded if default_label_crs_ok else self.DEFAULT_LABEL_CRS_DEFAULT
+
+    def _open_config_dialog(self):
+        dialog = QDialog(self.iface.mainWindow())
+        dialog.setWindowTitle("THW Toolbox Einstellungen")
+        layout = QVBoxLayout(dialog)
+
+        form = QFormLayout()
+
+        # Scaling with Map Setting
+        cb_scale = QCheckBox()
+        cb_scale.setChecked(self.settings.get("scaling_icon_with_map",self.SCALING_ICON_WITH_MAP_DEFAULT))
+        form.addRow("Neue Zeichen mit Karte skalieren", cb_scale)
+
+        # Automatic Fixed Size Setting
+        cb_fixed_size = QCheckBox()
+        cb_fixed_size.setChecked(self.settings.get("icon_fixed_size", self.ICON_FIXED_SIZE_DEFAULT))
+        form.addRow("Neue Zeichen mit fixer Standardgröße", cb_fixed_size)
+
+        # Default Size (only active if cb_fixed_size is enabled)
+        spin_icon_size =QSpinBox()
+        spin_icon_size.setMinimum(10)
+        spin_icon_size.setMaximum(200)
+        spin_icon_size.setValue(self.settings.get("default_icon_size",self.DEFAULT_ICON_SIZE_DEFAULT))
+        spin_icon_size.setSingleStep(1)  # Schrittweite
+        form.addRow("Fixe Standardgröße für neue Zeichen",spin_icon_size)
+        def update_spin_icon_size(checked):
+            spin_icon_size.setEnabled(checked)
+        cb_fixed_size.stateChanged.connect(update_spin_icon_size)
+        update_spin_icon_size(cb_fixed_size.isChecked())
+
+        # Coordinate System of Label
+        dropdown_crs = QComboBox()
+        dropdown_crs.addItems(["MGRS","UTM"])
+        current_index = dropdown_crs.findText(self.settings.get("default_label_crs",self.DEFAULT_LABEL_CRS_DEFAULT))
+        if current_index >= 0:
+            dropdown_crs.setCurrentIndex(current_index)
+        form.addRow("Koordinantesystem für Standortbeschriftung", dropdown_crs)
+
+        layout.addLayout(form)
+
+        # Bestätigen / Abbrechen
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        layout.addWidget(button_box)
+        button_box.accepted.connect(dialog.accept)
+        button_box.rejected.connect(dialog.reject)
+
+        result = dialog.exec_()
+        if result is not QDialog.Rejected:
+            self.settings["scaling_icon_with_map"] = cb_scale.isChecked()
+            self.settings["icon_fixed_size"] = cb_fixed_size.isChecked()
+            self.settings["default_icon_size"] = spin_icon_size.value()
+            self.settings["default_label_crs"] = dropdown_crs.currentText()
+            self._save_settings()
+
+    def _save_settings(self):
+        proj = QgsProject.instance()
+
+        # Save the current settings
+        proj.writeEntryBool("taktischezeichen", "scaling_icon_with_map", bool(self.settings.get("scaling_icon_with_map", self.SCALING_ICON_WITH_MAP_DEFAULT)))
+        proj.writeEntryBool("taktischezeichen", "icon_fixed_size", bool(self.settings.get("icon_fixed_size", self.ICON_FIXED_SIZE_DEFAULT)))
+        proj.writeEntry("taktischezeichen", "default_icon_size", int(self.settings.get("default_icon_size", self.DEFAULT_ICON_SIZE_DEFAULT)))
+        proj.writeEntry("taktischezeichen", "default_label_crs", str(self.settings.get("default_label_crs", self.DEFAULT_LABEL_CRS_DEFAULT)))
+        proj.setDirty(True)
+        print("DEBUG: Config saved.")
+
 
     def resize_feature(self, fid, size):
         if not self.layer:

--- a/thwtoolboxplugin.py
+++ b/thwtoolboxplugin.py
@@ -12,6 +12,7 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QDockWidget,
     QFormLayout,
+    QGroupBox,
     QHBoxLayout,
     QInputDialog,
     QLabel,
@@ -55,6 +56,7 @@ from qgis.utils import iface
 
 from .identifytool import FeatureDock
 from .thwtoolboxplugin_dock import SvgDock
+from .thwtoolboxsettings import THWToolboxSettings
 
 
 class CanvasDropFilter(QObject):
@@ -310,12 +312,6 @@ class MoveTool(QgsMapTool):
 
 class THWToolboxPlugin:
 
-    # Default values for settings
-    SCALING_ICON_WITH_MAP_DEFAULT = False
-    ICON_FIXED_SIZE_DEFAULT = False
-    DEFAULT_ICON_SIZE_DEFAULT = 50
-    DEFAULT_LABEL_CRS_DEFAULT = "MGRS"
-
     def __init__(self, iface):
         self.iface = iface
         self.canvas = iface.mapCanvas()
@@ -328,12 +324,7 @@ class THWToolboxPlugin:
         self.action = None
         self.dock = None
 
-        self.settings = {
-            "scaling_icon_with_map": self.SCALING_ICON_WITH_MAP_DEFAULT,
-            "icon_fixed_size": self.ICON_FIXED_SIZE_DEFAULT,
-            "default_icon_size": self.DEFAULT_ICON_SIZE_DEFAULT,
-            "default_label_crs": self.DEFAULT_LABEL_CRS_DEFAULT,
-        }
+        self.settings = THWToolboxSettings()
 
     def _check_map_available(self):
         """Prüft, ob eine Karte vorhanden ist (CRS gesetzt und Layer im Projekt)."""
@@ -472,7 +463,7 @@ class THWToolboxPlugin:
         self.canvas.setMapTool(self.move_tool)
 
         # Load the configuration settings
-        self._load_settings()
+        self.settings.load_settings(QgsProject.instance())
 
         # Plugin-Symbol als aktiv markieren
         if self.action:
@@ -928,8 +919,8 @@ class THWToolboxPlugin:
 
             # Text-Format konfigurieren
             text_format = QgsTextFormat()
-            text_format.setSize(200)  # Schriftgröße (deutlich größer für bessere Lesbarkeit)
-            text_format.setSizeUnit(QgsUnitTypes.RenderPoints)  # Einheit: Punkte
+            text_format.setSize(self.settings.label_font_size_mm)  # Schriftgröße (deutlich größer für bessere Lesbarkeit)
+            text_format.setSizeUnit(Qgis.RenderUnit.Millimeters)  # Einheit: Punkte
             text_format.setColor(Qt.black)
             # Verwende fette Schrift für bessere Sichtbarkeit
             font = text_format.font()
@@ -939,8 +930,8 @@ class THWToolboxPlugin:
             # Buffer-Einstellungen für bessere Lesbarkeit
             buffer_settings = QgsTextBufferSettings()
             buffer_settings.setEnabled(True)
-            buffer_settings.setSize(20.0)  # Buffer-Größe (größer für bessere Lesbarkeit)
-            buffer_settings.setSizeUnit(QgsUnitTypes.RenderPoints)  # Einheit: Punkte
+            buffer_settings.setSize(self.settings.label_buffer_size_mm)  # Buffer-Größe (größer für bessere Lesbarkeit)
+            buffer_settings.setSizeUnit(Qgis.RenderUnit.Millimeters)  # Einheit: Punkte
             buffer_settings.setColor(Qt.white)
             text_format.setBuffer(buffer_settings)
 
@@ -959,29 +950,12 @@ class THWToolboxPlugin:
                 # In QGIS 3.x könnte Show ein Integer oder eine Enum sein
                 show_property = QgsProperty.fromExpression(expr)
 
-                # Versuche verschiedene Methoden, die Property zu setzen
-                try:
-                    # Methode 1: Direkt über dataDefinedProperties()
-                    # Show könnte Property 0 sein
-                    label_settings.dataDefinedProperties().setProperty(0, show_property)
-                    print(f"DEBUG: Label-Expression gesetzt (Property 0): {expr}")
-                except Exception as e1:
-                    print(f"DEBUG: Methode 1 fehlgeschlagen: {e1}")
-                    try:
-                        # Methode 2: Versuche mit Show als String
-                        if hasattr(QgsPalLayerSettings, "Show"):
-                            show_attr = getattr(QgsPalLayerSettings, "Show")
-                            label_settings.dataDefinedProperties().setProperty(show_attr, show_property)
-                            print(f"DEBUG: Label-Expression gesetzt (Show-Attribut): {expr}")
-                        else:
-                            raise Exception("Show-Attribut nicht gefunden")
-                    except Exception as e2:
-                        print(f"DEBUG: Methode 2 fehlgeschlagen: {e2}")
-                        # Methode 3: Verwende displayField als Expression mit Filter
-                        # Setze das Label-Feld als Expression, die die Bedingung prüft
-                        label_settings.isExpression = True
-                        label_settings.fieldName = 'CASE WHEN "show_label" = 1 AND "label" IS NOT NULL AND "label" <> \'\' THEN "label" ELSE \'\' END'
-                        print(f"DEBUG: Label-Expression als Feld-Expression gesetzt: {label_settings.fieldName}")
+                label_props = label_settings.dataDefinedProperties()
+                if self.settings.label_enable:
+                    label_props.setProperty(QgsPalLayerSettings.Property.Show, show_property)
+                else:
+                    label_props.setProperty(QgsPalLayerSettings.Property.Show, False)
+
             except Exception as e:
                 print(f"DEBUG: Fehler beim Setzen der Expression: {e}")
                 import traceback
@@ -998,86 +972,40 @@ class THWToolboxPlugin:
                     print("DEBUG: Labels werden ohne Filter angezeigt")
 
             # Label-Positionierung - unter dem Symbol
-            # Verwende Qgis.LabelPlacement Enum statt Integer
             try:
-                # Versuche verschiedene Enum-Werte für AroundPoint (um das Symbol herum)
-                if hasattr(Qgis, "LabelPlacement"):
-                    # QGIS 3.x: LabelPlacement ist in Qgis verschoben
-                    # AroundPoint erlaubt Positionierung um das Symbol herum
-                    if hasattr(Qgis.LabelPlacement, "AroundPoint"):
-                        label_settings.placement = Qgis.LabelPlacement.AroundPoint
-                    elif hasattr(Qgis.LabelPlacement, "OffsetPoint"):
-                        label_settings.placement = Qgis.LabelPlacement.OffsetPoint
-                    else:
-                        # Versuche mit Integer-Wert (0 = AroundPoint)
-                        label_settings.placement = 0
-                    print(f"DEBUG: Placement gesetzt: {label_settings.placement}")
-                elif hasattr(QgsPalLayerSettings, "AroundPoint"):
-                    # Fallback für ältere Versionen
-                    label_settings.placement = QgsPalLayerSettings.AroundPoint
-                    print(f"DEBUG: Placement gesetzt (QgsPalLayerSettings): {label_settings.placement}")
+                # 1) Place labels around the point (cartographic / ordered positions)
+                if hasattr(Qgis, "LabelPlacement") and hasattr(Qgis.LabelPlacement, "OverPoint"):
+                    label_settings.placement = Qgis.LabelPlacement.OverPoint
                 else:
-                    # Letzter Fallback: Versuche mit Integer (0 = AroundPoint)
-                    label_settings.placement = 0
-                    print(f"DEBUG: Placement gesetzt (Integer): {label_settings.placement}")
-            except Exception as e:
-                print(f"DEBUG: Fehler beim Setzen von placement: {e}")
-                import traceback
+                    # Fallback for older versions
+                    label_settings.placement = QgsPalLayerSettings.OverPoint
 
-                traceback.print_exc()
-                # Verwende Standard-Placement
-                try:
-                    if hasattr(Qgis, "LabelPlacement"):
-                        label_settings.placement = Qgis.LabelPlacement.AroundPoint
+                # 2) Tell QGIS to put the label in the bottom/below quadrant of the point
+                if hasattr(Qgis, "LabelQuadrantPosition"):
+                    # QGIS >= 3.26: use the new enum
+                    label_settings.quadOffset = Qgis.LabelQuadrantPosition.Below
+                else:
+                    # Older API: use QuadrantPosition enum from QgsPalLayerSettings
+                    if hasattr(QgsPalLayerSettings, "BottomMiddle"):
+                        label_settings.quadOffset = QgsPalLayerSettings.BottomMiddle
+                    elif hasattr(QgsPalLayerSettings, "Bottom"):
+                        label_settings.quadOffset = QgsPalLayerSettings.Bottom
                     else:
-                        label_settings.placement = 0
-                except:
-                    label_settings.placement = 0
+                        # last resort: standard bottom-middle index
+                        label_settings.quadOffset = QgsPalLayerSettings.BottomMiddle if hasattr(
+                            QgsPalLayerSettings, "BottomMiddle"
+                        ) else 0
+            except Exception as e:
+                print(f"DEBUG: Position festsetzen fehlgeschlagen: {e}")
 
-            # quadOffset für Positionierung - unter dem Symbol (unten)
             try:
-                if hasattr(Qgis, "LabelQuadrant"):
-                    # QGIS 3.x: LabelQuadrant ist in Qgis verschoben
-                    # Bottom = unter dem Symbol
-                    if hasattr(Qgis.LabelQuadrant, "Bottom"):
-                        label_settings.quadOffset = Qgis.LabelQuadrant.Bottom
-                    elif hasattr(Qgis.LabelQuadrant, "BottomCenter"):
-                        label_settings.quadOffset = Qgis.LabelQuadrant.BottomCenter
-                    elif hasattr(Qgis.LabelQuadrant, "BottomLeft"):
-                        label_settings.quadOffset = Qgis.LabelQuadrant.BottomLeft
-                    elif hasattr(Qgis.LabelQuadrant, "BottomRight"):
-                        label_settings.quadOffset = Qgis.LabelQuadrant.BottomRight
-                    else:
-                        # Versuche mit Integer-Wert (6 = Bottom in manchen Versionen)
-                        label_settings.quadOffset = 6
-                    print(f"DEBUG: quadOffset gesetzt (unter Symbol): {label_settings.quadOffset}")
-                elif hasattr(Qgis, "QuadrantPosition"):
-                    # Alternative: QuadrantPosition
-                    if hasattr(Qgis.QuadrantPosition, "Bottom"):
-                        label_settings.quadOffset = Qgis.QuadrantPosition.Bottom
-                    elif hasattr(Qgis.QuadrantPosition, "BottomCenter"):
-                        label_settings.quadOffset = Qgis.QuadrantPosition.BottomCenter
-                    else:
-                        label_settings.quadOffset = 6
-                    print(f"DEBUG: quadOffset gesetzt (QuadrantPosition): {label_settings.quadOffset}")
-                else:
-                    # Fallback: Versuche mit Integer (6 = Bottom)
-                    try:
-                        label_settings.quadOffset = 6  # Bottom
-                        print(f"DEBUG: quadOffset gesetzt (Integer 6 = Bottom)")
-                    except:
-                        print("DEBUG: LabelQuadrant/QuadrantPosition nicht verfügbar, überspringe quadOffset")
+                # Offset-Werte in Points , Abstand abhängig von der Größe des Zeichens
+                if hasattr(Qgis, "RenderUnit") and hasattr(Qgis.RenderUnit, "Points"):
+                    label_settings.offsetUnits = Qgis.RenderUnit.Points
+                size_property = QgsProperty.fromExpression("array(0,size)")
+                label_props.setProperty(QgsPalLayerSettings.Property.OffsetXY, size_property)
             except Exception as e:
-                print(f"DEBUG: Fehler beim Setzen von quadOffset: {e}")
-                import traceback
-
-                traceback.print_exc()
-                # Überspringe quadOffset, wenn es nicht funktioniert
-                pass
-
-            # Offset-Werte in Map Units - vertikaler Offset nach unten
-            label_settings.xOffset = 0.0  # Horizontaler Offset (zentriert)
-            label_settings.yOffset = -3.0  # Vertikaler Offset nach unten (negativ = nach unten, größerer Abstand)
+                print(f"DEBUG: Fehler bei der Festsetzung der Position: {e}")
 
             # Labeling auf Layer anwenden
             layer.setLabelsEnabled(True)
@@ -1132,7 +1060,7 @@ class THWToolboxPlugin:
             return
 
         # Save the settings
-        self._save_settings()
+        self.settings.save_settings(QgsProject.instance())
 
         # Aktuelle Datei-Pfad ermitteln
         current_source = self.layer.source().split("|")[0]
@@ -1469,8 +1397,8 @@ class THWToolboxPlugin:
         else:
             relative_path = svg_path
 
-        if self.settings.get("icon_fixed_size", self.ICON_FIXED_SIZE_DEFAULT):
-            icon_size = self.settings.get("default_icon_size", self.DEFAULT_ICON_SIZE_DEFAULT)
+        if self.settings.new_icon_fixed_size:
+            icon_size = self.settings.new_icon_size
         else:
             # Intelligente Größenberechnung basierend auf dem aktuellen Zoom-Faktor
             map_units_per_pixel = self.canvas.mapUnitsPerPixel()
@@ -1507,7 +1435,7 @@ class THWToolboxPlugin:
         f.setAttribute("svg_path", relative_path)  # Relativer Pfad
         f.setAttribute("svg_content", svg_content)  # SVG-Inhalt speichern
         f.setAttribute("size", icon_size)  # Adaptive Größe basierend auf Zoom-Faktor
-        f.setAttribute("scale_with_map", self.settings.get("scaling_icon_with_map", self.SCALING_ICON_WITH_MAP_DEFAULT))  # Standardmäßig nicht mit Karte skalieren
+        f.setAttribute("scale_with_map", self.settings.new_icon_scaling_with_map)  # Standardmäßig nicht mit Karte skalieren
         f.setAttribute("unique_id", str(uuid.uuid4()))  # Eindeutige ID generieren
         f.setAttribute("label", default_label)  # Standard-Label aus SVG-Namen
         f.setAttribute("show_label", False)  # Label standardmäßig nicht anzeigen
@@ -1689,44 +1617,34 @@ class THWToolboxPlugin:
         # Layer-Referenzen in anderen Klassen aktualisieren
         self._update_tool_references()
 
-    def _load_settings(self):
-        proj = QgsProject.instance()
-
-        scaling_icon_with_map_loaded, scaling_icon_with_map_ok = proj.readBoolEntry("taktischezeichen", "scaling_icon_with_map", self.SCALING_ICON_WITH_MAP_DEFAULT)
-        icon_fixed_size_loaded, icon_fixed_size_ok = proj.readBoolEntry("taktischezeichen", "icon_fixed_size", self.ICON_FIXED_SIZE_DEFAULT)
-        default_icon_size_loaded, default_icon_size_ok = proj.readNumEntry("taktischezeichen", "default_icon_size", self.DEFAULT_ICON_SIZE_DEFAULT)
-        default_label_crs_loaded, default_label_crs_ok = proj.readEntry("taktischezeichen", "default_label_crs", self.DEFAULT_LABEL_CRS_DEFAULT)
-
-        print(f"DEBUG: Tried to load settings with result {scaling_icon_with_map_ok} and return {scaling_icon_with_map_loaded}")
-        self.settings["scaling_icon_with_map"] = scaling_icon_with_map_loaded if scaling_icon_with_map_ok else self.SCALING_ICON_WITH_MAP_DEFAULT
-        self.settings["icon_fixed_size"] = icon_fixed_size_loaded if icon_fixed_size_ok else self.ICON_FIXED_SIZE_DEFAULT
-        self.settings["default_icon_size"] = default_icon_size_loaded if default_icon_size_ok else self.DEFAULT_ICON_SIZE_DEFAULT
-        self.settings["default_label_crs"] = default_label_crs_loaded if default_label_crs_ok else self.DEFAULT_LABEL_CRS_DEFAULT
+    
 
     def _open_config_dialog(self):
         dialog = QDialog(self.iface.mainWindow())
         dialog.setWindowTitle("THW Toolbox Einstellungen")
         layout = QVBoxLayout(dialog)
 
-        form = QFormLayout()
+        ##### Default Icon Settings #####
+        default_icon_settings_box = QGroupBox("Einstellungen für neue Zeichen")
+        default_icon_form = QFormLayout()
 
         # Scaling with Map Setting
         cb_scale = QCheckBox()
-        cb_scale.setChecked(self.settings.get("scaling_icon_with_map",self.SCALING_ICON_WITH_MAP_DEFAULT))
-        form.addRow("Neue Zeichen mit Karte skalieren", cb_scale)
+        cb_scale.setChecked(self.settings.new_icon_scaling_with_map)
+        default_icon_form.addRow("Neue Zeichen mit Karte skalieren", cb_scale)
 
         # Automatic Fixed Size Setting
         cb_fixed_size = QCheckBox()
-        cb_fixed_size.setChecked(self.settings.get("icon_fixed_size", self.ICON_FIXED_SIZE_DEFAULT))
-        form.addRow("Neue Zeichen mit fixer Standardgröße", cb_fixed_size)
+        cb_fixed_size.setChecked(self.settings.new_icon_fixed_size)
+        default_icon_form.addRow("Neue Zeichen mit fixer Standardgröße", cb_fixed_size)
 
         # Default Size (only active if cb_fixed_size is enabled)
         spin_icon_size =QSpinBox()
         spin_icon_size.setMinimum(10)
         spin_icon_size.setMaximum(200)
-        spin_icon_size.setValue(self.settings.get("default_icon_size",self.DEFAULT_ICON_SIZE_DEFAULT))
+        spin_icon_size.setValue(self.settings.new_icon_size)
         spin_icon_size.setSingleStep(1)  # Schrittweite
-        form.addRow("Fixe Standardgröße für neue Zeichen",spin_icon_size)
+        default_icon_form.addRow("Fixe Standardgröße für neue Zeichen",spin_icon_size)
         def update_spin_icon_size(checked):
             spin_icon_size.setEnabled(checked)
         cb_fixed_size.stateChanged.connect(update_spin_icon_size)
@@ -1735,12 +1653,42 @@ class THWToolboxPlugin:
         # Coordinate System of Label
         dropdown_crs = QComboBox()
         dropdown_crs.addItems(["MGRS","UTM"])
-        current_index = dropdown_crs.findText(self.settings.get("default_label_crs",self.DEFAULT_LABEL_CRS_DEFAULT))
+        current_index = dropdown_crs.findText(self.settings.new_icon_crs)
         if current_index >= 0:
             dropdown_crs.setCurrentIndex(current_index)
-        form.addRow("Koordinantesystem für Standortbeschriftung", dropdown_crs)
+        default_icon_form.addRow("Koordinantesystem für Standortbeschriftung", dropdown_crs)
 
-        layout.addLayout(form)
+        default_icon_settings_box.setLayout(default_icon_form)
+        layout.addWidget(default_icon_settings_box)
+
+        ##### Label Settings #####
+        label_settings_box = QGroupBox("Label Settings")
+        label_settings_form = QFormLayout()
+
+        # Global Enable
+        cb_label_enable = QCheckBox()
+        cb_label_enable.setChecked(self.settings.label_enable)
+        label_settings_form.addRow("Aktivierte Labels anzeigen", cb_label_enable)
+
+        # Label Size
+        sb_label_font_size = QSpinBox()
+        sb_label_font_size.setMinimum(1)
+        sb_label_font_size.setMaximum(100)
+        sb_label_font_size.setSingleStep(1)
+        sb_label_font_size.setValue(int(self.settings.label_font_size_mm * 10))
+        label_settings_form.addRow("Label Schriftgröße in mm", sb_label_font_size)
+
+        # Buffer Size
+        sb_label_buffer_size = QSpinBox()
+        sb_label_buffer_size.setMinimum(1)
+        sb_label_buffer_size.setMaximum(50)
+        sb_label_buffer_size.setSingleStep(1)
+        sb_label_buffer_size.setValue(int(self.settings.label_buffer_size_mm * 10))
+        label_settings_form.addRow("Label Rahmendicke in mm", sb_label_buffer_size)
+
+        label_settings_box.setLayout(label_settings_form)
+        layout.addWidget(label_settings_box)
+
 
         # Bestätigen / Abbrechen
         button_box = QDialogButtonBox(
@@ -1752,22 +1700,17 @@ class THWToolboxPlugin:
 
         result = dialog.exec_()
         if result is not QDialog.Rejected:
-            self.settings["scaling_icon_with_map"] = cb_scale.isChecked()
-            self.settings["icon_fixed_size"] = cb_fixed_size.isChecked()
-            self.settings["default_icon_size"] = spin_icon_size.value()
-            self.settings["default_label_crs"] = dropdown_crs.currentText()
-            self._save_settings()
+            self.settings.new_icon_scaling_with_map = cb_scale.isChecked()
+            self.settings.new_icon_fixed_size = cb_fixed_size.isChecked()
+            self.settings.new_icon_size = spin_icon_size.value()
+            self.settings.new_icon_crs = dropdown_crs.currentText()
 
-    def _save_settings(self):
-        proj = QgsProject.instance()
+            self.settings.label_enable = cb_label_enable.isChecked()
+            self.settings.label_font_size_mm = sb_label_font_size.value() / 10.0
+            self.settings.label_buffer_size_mm = sb_label_buffer_size.value() / 10.0
 
-        # Save the current settings
-        proj.writeEntryBool("taktischezeichen", "scaling_icon_with_map", bool(self.settings.get("scaling_icon_with_map", self.SCALING_ICON_WITH_MAP_DEFAULT)))
-        proj.writeEntryBool("taktischezeichen", "icon_fixed_size", bool(self.settings.get("icon_fixed_size", self.ICON_FIXED_SIZE_DEFAULT)))
-        proj.writeEntry("taktischezeichen", "default_icon_size", int(self.settings.get("default_icon_size", self.DEFAULT_ICON_SIZE_DEFAULT)))
-        proj.writeEntry("taktischezeichen", "default_label_crs", str(self.settings.get("default_label_crs", self.DEFAULT_LABEL_CRS_DEFAULT)))
-        proj.setDirty(True)
-        print("DEBUG: Config saved.")
+            self.settings.save_settings(QgsProject.instance())
+            self._init_renderer(self.layer)
 
 
     def resize_feature(self, fid, size):

--- a/thwtoolboxplugin.py
+++ b/thwtoolboxplugin.py
@@ -1656,7 +1656,7 @@ class THWToolboxPlugin:
         current_index = dropdown_crs.findText(self.settings.new_icon_crs)
         if current_index >= 0:
             dropdown_crs.setCurrentIndex(current_index)
-        default_icon_form.addRow("Koordinantesystem für Standortbeschriftung", dropdown_crs)
+        # default_icon_form.addRow("Koordinantesystem für Standortbeschriftung", dropdown_crs)
 
         default_icon_settings_box.setLayout(default_icon_form)
         layout.addWidget(default_icon_settings_box)
@@ -1676,7 +1676,7 @@ class THWToolboxPlugin:
         sb_label_font_size.setMaximum(100)
         sb_label_font_size.setSingleStep(1)
         sb_label_font_size.setValue(int(self.settings.label_font_size_mm * 10))
-        label_settings_form.addRow("Label Schriftgröße in mm", sb_label_font_size)
+        label_settings_form.addRow("Label Schriftgröße", sb_label_font_size)
 
         # Buffer Size
         sb_label_buffer_size = QSpinBox()
@@ -1684,7 +1684,7 @@ class THWToolboxPlugin:
         sb_label_buffer_size.setMaximum(50)
         sb_label_buffer_size.setSingleStep(1)
         sb_label_buffer_size.setValue(int(self.settings.label_buffer_size_mm * 10))
-        label_settings_form.addRow("Label Rahmendicke in mm", sb_label_buffer_size)
+        label_settings_form.addRow("Label Rahmendicke", sb_label_buffer_size)
 
         label_settings_box.setLayout(label_settings_form)
         layout.addWidget(label_settings_box)

--- a/thwtoolboxplugin_dock.py
+++ b/thwtoolboxplugin_dock.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import (
     QListWidgetItem,
     QTreeWidget,
     QTreeWidgetItem,
+    QPushButton,
     QVBoxLayout,
     QWidget,
 )
@@ -24,7 +25,7 @@ logging.basicConfig(
 
 
 class SvgDock(QWidget):
-    def __init__(self, plugin_dir, select_callback):
+    def __init__(self, plugin_dir, select_callback, settings_callback):
         super().__init__()
         self.plugin_dir = plugin_dir
         self.select_callback = select_callback
@@ -56,6 +57,12 @@ class SvgDock(QWidget):
         self.populate_root_folders()
         self.treeWidget.itemPressed.connect(self.on_item_pressed)
         self.treeWidget.itemExpanded.connect(self.on_item_expanded)
+
+        # Button für die Einstellung hinzufügen
+        self.btn_config = QPushButton("Einstellungen")
+        self.btn_config.clicked.connect(settings_callback)
+        layout.addWidget(self.btn_config)
+
 
     def get_cached_icon(self, path):
         if path not in self.icon_cache:

--- a/thwtoolboxsettings.py
+++ b/thwtoolboxsettings.py
@@ -1,0 +1,142 @@
+
+class THWToolboxSettings:
+    # Default values for settings
+    NEW_ICON_SCALING_WITH_MAP_DEFAULT = False
+    NEW_ICON_FIXED_SIZE_DEFAULT = False
+    NEW_ICON_SIZE_DEFAULT = 50
+    NEW_ICON_CRS_DEFAULT = "MGRS"
+    LABEL_ENABLE_DEFAULT = True
+    LABEL_FONT_SIZE_DEFAULT_UM = 6000
+    LABEL_BUFFER_SIZE_DEFAULT_UM = 1000
+
+    # Save-File values
+    PLUGIN_NAME = "taktischezeichen"
+
+
+    def __init__(self):
+        self._new_icon_scaling_with_map = self.NEW_ICON_SCALING_WITH_MAP_DEFAULT
+        self._new_icon_fixed_size = self.NEW_ICON_FIXED_SIZE_DEFAULT
+        self._new_icon_size = self.NEW_ICON_SIZE_DEFAULT
+        self._new_icon_crs = self.NEW_ICON_CRS_DEFAULT
+
+        self._label_enable = self.LABEL_ENABLE_DEFAULT
+        self._label_font_size_mm = 1000 * self.LABEL_FONT_SIZE_DEFAULT_UM
+        self._label_buffer_size_mm = 1000* self.LABEL_BUFFER_SIZE_DEFAULT_UM
+
+    @property
+    def new_icon_scaling_with_map(self) -> bool:
+        return self._new_icon_scaling_with_map
+    @new_icon_scaling_with_map.setter
+    def new_icon_scaling_with_map(self, value):
+        if not isinstance(value, bool):
+            raise ValueError("Scaling must be a bool")
+        self._new_icon_scaling_with_map = value
+
+    @property
+    def new_icon_fixed_size(self) -> bool:
+        return self._new_icon_fixed_size
+    @new_icon_fixed_size.setter
+    def new_icon_fixed_size(self, value):
+        if not isinstance(value, bool):
+            raise ValueError("Fixed size must be a bool")
+        self._new_icon_fixed_size = value
+
+    @property
+    def new_icon_size(self) -> int:
+        return self._new_icon_size
+    @new_icon_size.setter
+    def new_icon_size(self, value):
+        if not isinstance(value, int) or value <= 0:
+            raise ValueError("Icon size must be a positive integer")
+        self._new_icon_size = value
+
+    @property
+    def new_icon_crs(self) -> str:
+        return self._new_icon_crs
+    @new_icon_crs.setter
+    def new_icon_crs(self, value):
+        if not isinstance(value, str):
+            raise ValueError("CRS must be a string")
+        self._new_icon_crs = value
+
+    @property
+    def label_enable(self) -> bool:
+        return self._label_enable
+    @label_enable.setter
+    def label_enable(self, value):
+        if not isinstance(value, bool):
+            raise ValueError("Label Enable must be a bool")
+        self._label_enable = value
+
+    @property
+    def label_font_size_mm(self) -> int:
+        return self._label_font_size_mm
+    @label_font_size_mm.setter
+    def label_font_size_mm(self, value):
+        if not isinstance(value, (int, float)) or value <= 0:
+            raise ValueError("Font size must be a positive number")
+        self._label_font_size_mm = int(value)
+
+    @property
+    def label_buffer_size_mm(self) -> int:
+        return self._label_buffer_size_mm
+    @label_buffer_size_mm.setter
+    def label_buffer_size_mm(self, value):
+        if not isinstance(value, (int, float)) or value <= 0:
+            raise ValueError("Buffer size must be a positive number")
+        self._label_buffer_size_mm = int(value)
+
+    def load_settings(self, proj):
+        """ Loads settings automatically from the defined private parameters
+        """
+        for attr_name in dir(self):
+            if attr_name.startswith('_') and not attr_name.startswith('__'):
+                private_field = attr_name
+                config_key = attr_name[1:]  # '_new_icon_scaling_with_map' → 'new_icon_scaling_with_map'
+
+                # logic for config key transformations
+                if private_field.endswith('_mm'):
+                    config_key = config_key.replace('_mm', '_um')
+                    default_value = getattr(self, f"{private_field[1:-3]}_DEFAULT_UM".upper())
+                    loaded_value, ok = proj.readNumEntry(self.PLUGIN_NAME, config_key, default_value)
+                    final_value = (loaded_value if ok else default_value) / 1000.0
+                else:
+                    default_value = getattr(self, f"{private_field[1:]}_DEFAULT".upper())
+                    if isinstance(default_value, bool):
+                        loaded_value, ok = proj.readBoolEntry(self.PLUGIN_NAME, config_key, default_value)
+                    elif isinstance(default_value, int):
+                        loaded_value, ok = proj.readNumEntry(self.PLUGIN_NAME, config_key, default_value)
+                    else:
+                        loaded_value, ok = proj.readEntry(self.PLUGIN_NAME, config_key, str(default_value))
+                    final_value = loaded_value if ok else default_value
+
+                # Set via public property (uses your existing setters with validation)
+                public_prop = private_field[1:]  # '_new_icon_scaling_with_map' → 'new_icon_scaling_with_map'
+                if hasattr(self, public_prop):
+                    setattr(self, public_prop, final_value)
+
+                print(f"DEBUG: Tried to load {config_key} with result {ok} and value {final_value}")
+
+        proj.setDirty(True)
+
+
+    def save_settings(self, proj):
+        """ Saves all private parameters into the project
+        """
+
+        for attr_name in dir(self):
+            if attr_name.startswith('_') and not attr_name.startswith('__'):
+                value = getattr(self, attr_name)
+                config_key = attr_name[1:] # Do not use the starting _ for key name
+
+                if isinstance(value, bool):
+                    proj.writeEntryBool(self.PLUGIN_NAME, config_key, value)
+                elif isinstance(value, str):
+                    proj.writeEntry(self.PLUGIN_NAME, config_key, str(value))
+                elif attr_name.endswith('_mm'):
+                    config_key = config_key.replace('_mm', '_um')
+                    proj.writeEntry(self.PLUGIN_NAME, config_key, value * 1000)
+                else:
+                    proj.writeEntry(self.PLUGIN_NAME, config_key, value)
+
+        proj.setDirty(True)

--- a/thwtoolboxsettings.py
+++ b/thwtoolboxsettings.py
@@ -20,8 +20,8 @@ class THWToolboxSettings:
         self._new_icon_crs = self.NEW_ICON_CRS_DEFAULT
 
         self._label_enable = self.LABEL_ENABLE_DEFAULT
-        self._label_font_size_mm = 1000 * self.LABEL_FONT_SIZE_DEFAULT_UM
-        self._label_buffer_size_mm = 1000* self.LABEL_BUFFER_SIZE_DEFAULT_UM
+        self._label_font_size_mm = self.LABEL_FONT_SIZE_DEFAULT_UM / 1000.0
+        self._label_buffer_size_mm = self.LABEL_BUFFER_SIZE_DEFAULT_UM / 1000.0
 
     @property
     def new_icon_scaling_with_map(self) -> bool:

--- a/thwtoolboxsettings.py
+++ b/thwtoolboxsettings.py
@@ -132,11 +132,11 @@ class THWToolboxSettings:
                 if isinstance(value, bool):
                     proj.writeEntryBool(self.PLUGIN_NAME, config_key, value)
                 elif isinstance(value, str):
-                    proj.writeEntry(self.PLUGIN_NAME, config_key, str(value))
+                    proj.writeEntry(self.PLUGIN_NAME, config_key, value)
                 elif attr_name.endswith('_mm'):
                     config_key = config_key.replace('_mm', '_um')
-                    proj.writeEntry(self.PLUGIN_NAME, config_key, value * 1000)
+                    proj.writeEntry(self.PLUGIN_NAME, config_key, int(value * 1000))
                 else:
-                    proj.writeEntry(self.PLUGIN_NAME, config_key, value)
+                    proj.writeEntry(self.PLUGIN_NAME, config_key, int(value))
 
         proj.setDirty(True)


### PR DESCRIPTION
- Added Settings view to set default options for new icons and configure label display
<img width="464" height="478" alt="image" src="https://github.com/user-attachments/assets/9e0e894c-33fa-47c9-990f-d21b2695b58a" />

- Added new file thwtoolboxsettings.py to store user changed settings in save file
- Completed display of labels, added relevant UI
<img width="1123" height="1272" alt="image" src="https://github.com/user-attachments/assets/04fa7fe9-f0d8-42cf-9c0d-613a104fb6bf" />

- Labels can be individually enabled or disabled in the icon settings (existing feature), all icons can be globally disabled through settings
- Developed on 3.44.7 from extra/qgis

ToDo:
- Test on 3.44.8 LTR
- Test on 4.0.0 Latest Stable