### PR TITLE
Fixed non-clipped logistic and command bars in facility markers

### DIFF
--- a/svgs/Einrichtungen/Feuerwehr_Einsatzzentrale.svg
+++ b/svgs/Einrichtungen/Feuerwehr_Einsatzzentrale.svg
@@ -18,12 +18,9 @@
     }
 ]]>
 		</style>
-		<clipPath id="base">
-			<ellipse cx="128" cy="128" rx="64" ry="64" />
-		</clipPath>
 	</defs>
 	<ellipse fill="#FFFF00" stroke="#000000" stroke-width="5" cx="128" cy="128" rx="64" ry="64" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 48px; text-anchor: middle;" x="128" y="153">FEZ</text>
-	<rect id="top" x="64" y="64" width="128" height="32" clip-path="url(#base)" />
+	<path d="M 128 64 A 64 64 0 0 0 72.574219 96 L 183.42578 96 A 64 64 0 0 0 128 64 z " />
 	<path d="M10 80 L128 48 L246 80" stroke-width="5" stroke="#000000" fill="none" />
 </svg>

--- a/svgs/Einrichtungen/Integrierte_Leitstelle.svg
+++ b/svgs/Einrichtungen/Integrierte_Leitstelle.svg
@@ -18,12 +18,9 @@
     }
 ]]>
 		</style>
-		<clipPath id="base">
-			<ellipse cx="128" cy="128" rx="64" ry="64" />
-		</clipPath>
 	</defs>
 	<ellipse fill="#FFFF00" stroke="#000000" stroke-width="5" cx="128" cy="128" rx="64" ry="64" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 48px; text-anchor: middle;" x="128" y="153">ILS</text>
-	<rect id="top" x="64" y="64" width="128" height="32" clip-path="url(#base)" />
+	<path d="M 128 64 A 64 64 0 0 0 72.574219 96 L 183.42578 96 A 64 64 0 0 0 128 64 z " />
 	<path d="M10 80 L128 48 L246 80" stroke-width="5" stroke="#000000" fill="none" />
 </svg>

--- a/svgs/Einrichtungen/Leitstelle.svg
+++ b/svgs/Einrichtungen/Leitstelle.svg
@@ -18,12 +18,9 @@
     }
 ]]>
 		</style>
-		<clipPath id="base">
-			<ellipse cx="128" cy="128" rx="64" ry="64" />
-		</clipPath>
 	</defs>
 	<ellipse fill="#FFFF00" stroke="#000000" stroke-width="5" cx="128" cy="128" rx="64" ry="64" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 48px; text-anchor: middle;" x="128" y="153">LSt</text>
-	<rect id="top" x="64" y="64" width="128" height="32" clip-path="url(#base)" />
+	<path d="M 128 64 A 64 64 0 0 0 72.574219 96 L 183.42578 96 A 64 64 0 0 0 128 64 z " />
 	<path d="M10 80 L128 48 L246 80" stroke-width="5" stroke="#000000" fill="none" />
 </svg>

--- a/svgs/Einrichtungen/Logistikstützpunkt.svg
+++ b/svgs/Einrichtungen/Logistikstützpunkt.svg
@@ -18,11 +18,8 @@
     }
 ]]>
 		</style>
-		<clipPath id="base">
-			<ellipse cx="128" cy="128" rx="64" ry="64" />
-		</clipPath>
 	</defs>
 	<ellipse fill="#FFFF00" stroke="#000000" stroke-width="5" cx="128" cy="128" rx="64" ry="64" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 48px; text-anchor: middle;" x="128" y="137">Log</text>
-	<rect x="64" y="160" width="128" height="32" clip-path="url(#base)" />
+	<path d="M 72.574219 160 A 64 64 0 0 0 128 192 A 64 64 0 0 0 183.42578 160 L 72.574219 160 z " />
 </svg>

--- a/svgs/Einrichtungen/Versorgungsstelle_Materialerhaltung.svg
+++ b/svgs/Einrichtungen/Versorgungsstelle_Materialerhaltung.svg
@@ -2,11 +2,8 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
 	<title>Versorgungsstelle Materialerhaltung</title>
 	<defs>
-		<clipPath id="base">
-			<ellipse cx="128" cy="128" rx="64" ry="64" />
-		</clipPath>
 	</defs>
 	<ellipse fill="#FFFF00" stroke="#000000" stroke-width="5" cx="128" cy="128" rx="64" ry="64" />
 	<path d="M75 140 a16 16 0 0 0 0 -32 m16 16 l74 0 M181 140 a16 16 0 0 1 0 -32" stroke="#000000" stroke-width="4" fill="none" />
-	<rect x="64" y="160" width="128" height="32" clip-path="url(#base)" />
+	<path d="M 72.574219 160 A 64 64 0 0 0 128 192 A 64 64 0 0 0 183.42578 160 L 72.574219 160 z " />
 </svg>

--- a/svgs/Einrichtungen/Versorgungsstelle_Verbrauchsgüter.svg
+++ b/svgs/Einrichtungen/Versorgungsstelle_Verbrauchsgüter.svg
@@ -1,12 +1,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
 	<title>Versorgungsstelle Verbrauchsgüter</title>
-	<defs>
-		<clipPath id="base">
-			<ellipse cx="128" cy="128" rx="64" ry="64" />
-		</clipPath>
-	</defs>
 	<ellipse fill="#FFFF00" stroke="#000000" stroke-width="5" cx="128" cy="128" rx="64" ry="64" />
 	<path d="M124 145 l0 -40 L110 85 l36 0 l-14 20 l0 40" stroke="#000000" stroke-width="3" fill="none" />
-	<rect x="64" y="160" width="128" height="32" clip-path="url(#base)" />
+	<path d="M 72.574219 160 A 64 64 0 0 0 128 192 A 64 64 0 0 0 183.42578 160 L 72.574219 160 z " />
 </svg>

--- a/svgs/Einrichtungen/Versorgungsstelle_Verpflegung.svg
+++ b/svgs/Einrichtungen/Versorgungsstelle_Verpflegung.svg
@@ -1,12 +1,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
 	<title>Versorgungsstelle Verpflegung</title>
-	<defs>
-		<clipPath id="base">
-			<ellipse cx="128" cy="128" rx="64" ry="64" />
-		</clipPath>
-	</defs>
 	<ellipse fill="#FFFF00" stroke="#000000" stroke-width="5" cx="128" cy="128" rx="64" ry="64" />
 	<path d="M128,120 l20,-10 a20 20 0 1 0 0,20 Z" stroke="#000000" stroke-width="5" fill="none" />
-	<rect x="64" y="160" width="128" height="32" clip-path="url(#base)" />
+	<path d="M 72.574219 160 A 64 64 0 0 0 128 192 A 64 64 0 0 0 183.42578 160 L 72.574219 160 z " />
 </svg>


### PR DESCRIPTION
Updated facility markers to clip logistic and command bars (reported in #6)

Root cause in the library Qt could not be resolved, therefor the other usages of clip-path are still open but have less visual impact.